### PR TITLE
Add Github Action for running test suite via Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: Standard React CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ci.Dockerfile
+
+    steps:
+    - name: Run Test Suite
+      run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,21 @@
-name: Standard React CI
+name: Anchor CI
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ci.Dockerfile
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build Docker Image
+      run: docker build -t anchor-program-test-env -f ci.Dockerfile .
+
     - name: Run Test Suite
-      run: yarn test
+      run: docker run anchor-program-test-env yarn test

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,0 +1,24 @@
+FROM node:lts
+
+# Setup Rust to build Solana
+RUN curl https://sh.rustup.rs -sSf | \
+  sh -s -- --default-toolchain stable -y
+ENV PATH=$PATH:/root/.cargo/bin
+
+# Install Solana to enable running test suite
+RUN sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+ENV PATH=$PATH:/root/.local/share/solana/install/active_release/bin/
+
+WORKDIR /usr/src/app
+
+# Install JS/TS deps
+COPY package.json ./
+COPY yarn.lock ./
+RUN yarn
+
+COPY . .
+
+# Setup dummy solana keypair for building and testing
+RUN solana-keygen new ----no-bip39-passphrase --silent
+
+CMD ["yarn","test"]


### PR DESCRIPTION
There are some notable pros/cons to using this approach of a Docker based build + test rather than "native" GH actions workflow. I like having it all live in Docker as it allows us to completely recreate the CI env on our local boxes, which makes debugging potential failures much easier. The downside is that we lose a lot of performance due to lack of ability to cache in this naive implementation. 

1 thing that could be cool in the future is actually publishing a docker container that is a sort of anchor test image. Include all the steps prior to the code copy & then the test run itself. That might actually let us re-use a lot of this work across different contract projects. 

Right now I configured the GH action to run on every push to main, and all PRs. If it's too resource intensive we could tweak those settings in the future. 