### PR TITLE
Store bumps as part of data accounts instead of passing in ix

### DIFF
--- a/scripts/swap_canonical_for_wrapped.ts
+++ b/scripts/swap_canonical_for_wrapped.ts
@@ -62,21 +62,17 @@ const main = async () => {
     canSwap.programId
   );
 
-  const [wrappedTokenAccountAuthority, wrappedTokenAccountAuthorityBump] =
-    await PublicKey.findProgramAddress(
-      [
-        WRAPPED_TOKEN_OWNER_AUTHORITY_PDA_SEED,
-        canonicalMint.toBuffer(),
-        wrappedMint.toBuffer(),
-      ],
-      canSwap.programId
-    );
+  const [wrappedTokenAccountAuthority] = await PublicKey.findProgramAddress(
+    [
+      WRAPPED_TOKEN_OWNER_AUTHORITY_PDA_SEED,
+      canonicalMint.toBuffer(),
+      wrappedMint.toBuffer(),
+    ],
+    canSwap.programId
+  );
 
   const tx = await canSwap.methods
-    .swapCanonicalForWrapped(
-      destinationAmount,
-      wrappedTokenAccountAuthorityBump
-    )
+    .swapCanonicalForWrapped(destinationAmount)
     .accounts({
       user: wallet.publicKey,
       sourceCanonicalTokenAccount: sourceTokenAccount,

--- a/scripts/swap_wrapped_for_canonical.ts
+++ b/scripts/swap_wrapped_for_canonical.ts
@@ -61,15 +61,14 @@ const main = async () => {
     provider
   ) as Program<CanonicalSwap>;
 
-  const [wrappedTokenAccountAuthority, wrappedTokenAccountAuthorityBump] =
-    await PublicKey.findProgramAddress(
-      [
-        WRAPPED_TOKEN_OWNER_AUTHORITY_PDA_SEED,
-        canonicalMint.toBuffer(),
-        wrappedMint.toBuffer(),
-      ],
-      canSwap.programId
-    );
+  const [wrappedTokenAccountAuthority] = await PublicKey.findProgramAddress(
+    [
+      WRAPPED_TOKEN_OWNER_AUTHORITY_PDA_SEED,
+      canonicalMint.toBuffer(),
+      wrappedMint.toBuffer(),
+    ],
+    canSwap.programId
+  );
 
   const [wrappedTokenAccount] = await PublicKey.findProgramAddress(
     [TOKEN_ACCOUNT_SEED, canonicalMint.toBuffer(), wrappedMint.toBuffer()],
@@ -77,10 +76,7 @@ const main = async () => {
   );
 
   const tx = await canSwap.methods
-    .swapCanonicalForWrapped(
-      new BN(destinationAmount),
-      wrappedTokenAccountAuthorityBump
-    )
+    .swapCanonicalForWrapped(new BN(destinationAmount))
     .accounts({
       user: wallet.publicKey,
       sourceCanonicalTokenAccount: sourceTokenAccount,

--- a/tests/method_enablers.ts
+++ b/tests/method_enablers.ts
@@ -49,11 +49,9 @@ describe("Method enablers", () => {
       wrappedData,
       canonicalMint,
       expectedMintAuthorityPDA,
-      mintAuthorityBump,
       wrappedMint,
       wrappedTokenAccount,
       wrappedTokenAccountAuthority,
-      wrappedTokenAccountAuthorityBump,
     } = await fixture(provider, wallet, canSwap));
   });
 
@@ -122,7 +120,7 @@ describe("Method enablers", () => {
       );
 
       const failedSwap = canSwap.methods
-        .swapCanonicalForWrapped(new BN(0), wrappedTokenAccountAuthorityBump)
+        .swapCanonicalForWrapped(new BN(0))
         .accounts({
           user: wallet.publicKey,
           sourceCanonicalTokenAccount: sourceTokenAccount,
@@ -172,7 +170,7 @@ describe("Method enablers", () => {
       );
 
       await canSwap.methods
-        .swapWrappedForCanonical(new BN(destinationAmount), mintAuthorityBump)
+        .swapWrappedForCanonical(new BN(destinationAmount))
         .accounts({
           user: wallet.publicKey,
           destinationCanonicalTokenAccount: destinationTokenAccount,
@@ -266,7 +264,7 @@ describe("Method enablers", () => {
       );
 
       const failedSwap = canSwap.methods
-        .swapWrappedForCanonical(new BN(0), mintAuthorityBump)
+        .swapWrappedForCanonical(new BN(0))
         .accounts({
           user: wallet.publicKey,
           destinationCanonicalTokenAccount: destinationTokenAccount,
@@ -317,10 +315,7 @@ describe("Method enablers", () => {
       );
 
       await canSwap.methods
-        .swapCanonicalForWrapped(
-          new BN(destinationAmount),
-          wrappedTokenAccountAuthorityBump
-        )
+        .swapCanonicalForWrapped(new BN(destinationAmount))
         .accounts({
           user: wallet.publicKey,
           sourceCanonicalTokenAccount: sourceTokenAccount,

--- a/tests/shared.ts
+++ b/tests/shared.ts
@@ -84,11 +84,10 @@ export const fixture = async (
     1000000000
   );
 
-  const [expectedMintAuthorityPDA, mintAuthorityBump] =
-    await PublicKey.findProgramAddress(
-      [CANONICAL_MINT_AUTHORITY_PDA_SEED, canonicalMint.toBuffer()],
-      canSwap.programId
-    );
+  const [expectedMintAuthorityPDA] = await PublicKey.findProgramAddress(
+    [CANONICAL_MINT_AUTHORITY_PDA_SEED, canonicalMint.toBuffer()],
+    canSwap.programId
+  );
 
   await canSwap.methods
     .initializeCanonicalToken()
@@ -122,15 +121,14 @@ export const fixture = async (
     canSwap.programId
   );
 
-  const [wrappedTokenAccountAuthority, wrappedTokenAccountAuthorityBump] =
-    await PublicKey.findProgramAddress(
-      [
-        WRAPPED_TOKEN_OWNER_AUTHORITY_PDA_SEED,
-        canonicalMint.toBuffer(),
-        wrappedMint.toBuffer(),
-      ],
-      canSwap.programId
-    );
+  const [wrappedTokenAccountAuthority] = await PublicKey.findProgramAddress(
+    [
+      WRAPPED_TOKEN_OWNER_AUTHORITY_PDA_SEED,
+      canonicalMint.toBuffer(),
+      wrappedMint.toBuffer(),
+    ],
+    canSwap.programId
+  );
 
   await canSwap.methods
     .initializeWrappedToken()
@@ -169,10 +167,8 @@ export const fixture = async (
     wrappedDecimals,
     canonicalMint,
     expectedMintAuthorityPDA,
-    mintAuthorityBump,
     wrappedMint,
     wrappedTokenAccount,
     wrappedTokenAccountAuthority,
-    wrappedTokenAccountAuthorityBump,
   };
 };

--- a/tests/swaps.ts
+++ b/tests/swaps.ts
@@ -38,9 +38,6 @@ describe("Swaps", () => {
   let wrappedTokenAccount: PublicKey;
   let wrappedTokenAccountAuthority: PublicKey;
 
-  let mintAuthorityBump: number;
-  let wrappedTokenAccountAuthorityBump: number;
-
   beforeEach("Set up fresh accounts", async () => {
     ({
       tokenDistributorTokenAccount,
@@ -49,11 +46,9 @@ describe("Swaps", () => {
       wrappedData,
       canonicalMint,
       expectedMintAuthorityPDA,
-      mintAuthorityBump,
       wrappedMint,
       wrappedTokenAccount,
       wrappedTokenAccountAuthority,
-      wrappedTokenAccountAuthorityBump,
     } = await fixture(provider, wallet, canSwap));
   });
 
@@ -76,7 +71,7 @@ describe("Swaps", () => {
       );
 
       const failedSwap = canSwap.methods
-        .swapWrappedForCanonical(new BN(0), mintAuthorityBump)
+        .swapWrappedForCanonical(new BN(0))
         .accounts({
           user: wallet.publicKey,
           destinationCanonicalTokenAccount: destinationTokenAccount,
@@ -140,7 +135,7 @@ describe("Swaps", () => {
       expect(preTxSourceTokenAccount.amount).to.eq(sourceAmount);
 
       await canSwap.methods
-        .swapWrappedForCanonical(new BN(destinationAmount), mintAuthorityBump)
+        .swapWrappedForCanonical(new BN(destinationAmount))
         .accounts({
           user: wallet.publicKey,
           destinationCanonicalTokenAccount: destinationTokenAccount,
@@ -197,7 +192,7 @@ describe("Swaps", () => {
       expect(preTxDestinationTokenAccount.amount).to.eq(BigInt(0));
 
       await canSwap.methods
-        .swapWrappedForCanonical(new BN(destinationAmount), mintAuthorityBump)
+        .swapWrappedForCanonical(new BN(destinationAmount))
         .accounts({
           user: wallet.publicKey,
           destinationCanonicalTokenAccount: destinationTokenAccount,
@@ -272,10 +267,7 @@ describe("Swaps", () => {
       expect(preTxSourceTokenAccount.amount).to.eq(sourceAmount);
 
       await canSwap.methods
-        .swapCanonicalForWrapped(
-          new BN(destinationAmount),
-          wrappedTokenAccountAuthorityBump
-        )
+        .swapCanonicalForWrapped(new BN(destinationAmount))
         .accounts({
           user: wallet.publicKey,
           sourceCanonicalTokenAccount: sourceTokenAccount,


### PR DESCRIPTION
I think this cleans up the calls by quite a bit so lets consider it for the deploy. Comments welcome