### PR TITLE
exclude security_txt from no-entrypoint builds

### DIFF
--- a/programs/canonical-swap/src/lib.rs
+++ b/programs/canonical-swap/src/lib.rs
@@ -3,6 +3,7 @@ use anchor_spl::token::{self, Burn, Mint, MintTo, SetAuthority, Token, TokenAcco
 use solana_security_txt::security_txt;
 use spl_token::instruction::AuthorityType;
 
+#[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     name: "Canonical Swap",
     project_url: "https://rly.network/",


### PR DESCRIPTION
The usage of `solana-security-txt` previously recommended in the official usage guide has an issue:

When multiple projects within a build, including dependencies, define a security-txt, the build fails.

To avoid this issue, library authors - including projects that *might* be used as a library by others in the future - should exclude the `security_txt` macro during `no-entrypoint` builds.

Feel free to read up on the details in [the issue on the security-txt repository](https://github.com/neodyme-labs/solana-security-txt/issues/11).

The [official usage guide](https://github.com/neodyme-labs/solana-security-txt#usage) has also been updated. This PR includes the recommended changes.
